### PR TITLE
Fixed coffee syntax error

### DIFF
--- a/vendor/assets/javascripts/hamlcoffee_amd.js.coffee.erb
+++ b/vendor/assets/javascripts/hamlcoffee_amd.js.coffee.erb
@@ -48,7 +48,7 @@ define ->
   #
   findAndPreserve: (text) ->
     tags = '<%= ::HamlCoffeeAssets.config.preserveTags %>'.split(',').join('|')
-    text = text.replace(/\r/g, '').replace ///<(#{ tags })>([\s\S]*?)<\/\1>/// g, (str, tag, content) ->
+    text = text.replace(/\r/g, '').replace ///<(#{ tags })>([\s\S]*?)<\/\1>///g, (str, tag, content) ->
       "<#{ tag }>#{ <%= ::HamlCoffeeAssets.config.customPreserve %>(content) }</#{ tag }>"
 
   # The surround helper surrounds the function output


### PR DESCRIPTION
Fix for `V8::Error: [stdin]:51:80: unexpected g at <eval>`